### PR TITLE
use gp3 type for ebs volumes

### DIFF
--- a/base/tks-cluster/infra/aws/resources.yaml
+++ b/base/tks-cluster/infra/aws/resources.yaml
@@ -34,7 +34,7 @@ spec:
       controlPlaneMachineType: TO_BE_FIXED
       rootVolume:
         size: 20 # GB
-        type: gp2
+        type: gp3
     machinePool: []
     machineDeployment: []
   wait: true
@@ -77,20 +77,22 @@ spec:
         image:
           repository: harbor.taco-cat.xyz/tks/csi-node-driver-registrar
     snapshotterSidecarEnabled: true
-    storageClasses: 
-    - name: taco-storage
-      # annotation metadata
-      annotations:
-        storageclass.kubernetes.io/is-default-class: "true"
-      # label metadata
-      labels:
-        support: taco-apps
-      # defaults to WaitForFirstConsumer
-      volumeBindingMode: WaitForFirstConsumer
-      # defaults to Delete
-      reclaimPolicy: Delete
-      parameters:
-        encrypted: "true"
+    storageClasses:
+      - name: taco-storage
+        # annotation metadata
+        annotations:
+          storageclass.kubernetes.io/is-default-class: "true"
+        # label metadata
+        labels:
+          support: taco-apps
+        # defaults to WaitForFirstConsumer
+        volumeBindingMode: WaitForFirstConsumer
+        # defaults to Delete
+        reclaimPolicy: Delete
+        parameters:
+          encrypted: "true"
+          csi.storage.k8s.io/fstype: ext4
+          type: gp3
 
   wait: true
 ---

--- a/base/tks-cluster/infra/aws/site-values.yaml
+++ b/base/tks-cluster/infra/aws/site-values.yaml
@@ -26,7 +26,7 @@ charts:
       maxSize: 16
       rootVolume:
         size: 200
-        type: gp2
+        type: gp3
       labels:
         taco-lma: enabled
         servicemesh: enabled

--- a/flow/organization/tks-cluster/create-usercluster-wftpl.yaml
+++ b/flow/organization/tks-cluster/create-usercluster-wftpl.yaml
@@ -560,8 +560,8 @@ spec:
             metadata:
               name: taco-storage
             parameters:
-              fsType: ext4
-              type: gp2
+              csi.storage.k8s.io/fstype: ext4
+              type: gp3
             provisioner: kubernetes.io/aws-ebs
             reclaimPolicy: Delete
             volumeBindingMode: WaitForFirstConsumer

--- a/site/aws-msa-reference/tks-cluster/site-values.yaml
+++ b/site/aws-msa-reference/tks-cluster/site-values.yaml
@@ -62,7 +62,7 @@ charts:
       maxSize: $(tksInfraNodeMax)
       rootVolume:
         size: 200
-        type: gp2
+        type: gp3
       labels:
         taco-lma: enabled
         servicemesh: enabled
@@ -79,7 +79,7 @@ charts:
       machineType: $(tksUserNodeType)
       rootVolume:
         size: 50
-        type: gp2
+        type: gp3
 
 - name: ingress-nginx
   override:

--- a/site/aws-reference/tks-cluster/site-values.yaml
+++ b/site/aws-reference/tks-cluster/site-values.yaml
@@ -62,7 +62,7 @@ charts:
       maxSize: $(tksInfraNodeMax)
       rootVolume:
         size: 200
-        type: gp2
+        type: gp3
       labels:
         taco-lma: enabled
         servicemesh: enabled
@@ -79,7 +79,7 @@ charts:
       machineType: $(tksUserNodeType)
       rootVolume:
         size: 50
-        type: gp2
+        type: gp3
 
 - name: ingress-nginx
   override:

--- a/site/eks-msa-reference/tks-cluster/site-values.yaml
+++ b/site/eks-msa-reference/tks-cluster/site-values.yaml
@@ -48,7 +48,7 @@ charts:
       maxSize: $(tksInfraNodeMax)
       rootVolume:
         size: 200
-        type: gp2
+        type: gp3
       labels:
         taco-lma: enabled
         servicemesh: enabled
@@ -63,7 +63,7 @@ charts:
       maxSize: $(tksUserNodeMax)
       rootVolume:
         size: 50
-        type: gp2
+        type: gp3
       roleAdditionalPolicies:
       - "arn:aws:iam::aws:policy/service-role/AmazonEBSCSIDriverPolicy"
 

--- a/site/eks-reference/tks-cluster/site-values.yaml
+++ b/site/eks-reference/tks-cluster/site-values.yaml
@@ -51,7 +51,7 @@ charts:
       maxSize: $(tksInfraNodeMax)
       rootVolume:
         size: 200
-        type: gp2
+        type: gp3
       labels:
         taco-lma: enabled
         servicemesh: enabled
@@ -66,7 +66,7 @@ charts:
       maxSize: $(tksUserNodeMax)
       rootVolume:
         size: 50
-        type: gp2
+        type: gp3
       roleAdditionalPolicies:
       - "arn:aws:iam::aws:policy/service-role/AmazonEBSCSIDriverPolicy"
 


### PR DESCRIPTION
AWS 환경에서 EBS 볼륨을 gp3 타입을 사용하도록 변경합니다.